### PR TITLE
fix: disallow `/api/`, `/health`, and other unwanted pages

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,11 +2,22 @@ import { MetadataRoute } from 'next'
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: '/projects',
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/projects',
+          '/api/',
+          '/health',
+          '/hooks/',
+          '/components/',
+          '/swagger/',
+          '/prompt/',
+          '/github.com/',
+        ],
+      },
+    ],
     sitemap: 'https://www.riannegreiros.xyz/sitemap.xml',
   }
 }


### PR DESCRIPTION
closes #321