### PR TITLE
refactor: allow `/api/sitemap` and `/api/rss` on `robots.ts`

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,7 +5,11 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: '*',
-        allow: '/',
+        allow: [
+          '/',
+          '/api/sitemap',
+          '/api/rss'
+        ],
         disallow: [
           '/projects',
           '/api/',


### PR DESCRIPTION
closes #331